### PR TITLE
allow for playing of local files which are in the sonos music library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ If you would like to use your local music (e.g. on a NAS) you can specify this i
 .. code-block:: yaml
 
     skills:
-      - pip: https://github.com/snipsco/snips-skills-sonos
+      - url: https://github.com/darioce/snips-skills-sonos
         package_name: snipssonos
         class_name: SnipsSonos
         params:

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,10 @@ It is recommended that you use this skill with the `Snips Skills Manager <https:
       - pip: https://github.com/snipsco/snips-skills-sonos
         package_name: snipssonos
         class_name: SnipsSonos
+        
 
-Usage
------
+Usage with Spotify
+------------------
 
 The skill allows you to control `Sonos <http://musicpartners.sonos.com/docs?q=node/442>`_ speakers. You can use it as follows:
 
@@ -38,6 +39,23 @@ The skill allows you to control `Sonos <http://musicpartners.sonos.com/docs?q=no
     sonos.play_artist("John Coltrane")
 
 The ``SPOTIFY_REFRESH_TOKEN`` is used for playing music from Spotify. You can obtain it from the `Snips Spotify Login <https://snips-spotify-login.herokuapp.com>`_ page.
+
+Useage with Sonos Local Music Library
+-------------------------------------
+
+If you would like to use your local music (e.g. on a NAS) you can specify this in the `Snipsfile <https://github.com/snipsco/snipsskills/wiki/The-Snipsfile>`_. The get_local_library_data.py allows you to pull your local artists, playlists etc. to include as custom slots in your assistant.
+
+.. code-block:: yaml
+
+    skills:
+      - pip: https://github.com/snipsco/snips-skills-sonos
+        package_name: snipssonos
+        class_name: SnipsSonos
+        params:
+                spotify_refresh_token: XXXXXXXXXX
+                speaker_index: 0
+                use_local_library: True
+                sonos_ip: XXX.XXX.XXX.XXX
 
 Copyright
 ---------

--- a/get_local_library_data.py
+++ b/get_local_library_data.py
@@ -1,0 +1,61 @@
+#! /usr/bin/env python
+# encoding: utf-8
+
+import argparse
+import codecs
+import soco
+
+from soco.music_services import MusicService
+
+def dump_item_list(sonos_ip_adress, mode, output_file):
+    if mode not in ['artists', 'tracks', 'albums', 'playlists']:
+            raise ValueError("mode argument should be 'artists', 'tracks', 'albums' or 'playlists'")
+    
+    device = soco.core.SoCo(sonos_ip_adress)
+    my_library = soco.music_library.MusicLibrary(device)
+    
+    items = my_library.get_music_library_information(mode, complete_result=True)
+    items_title = map(lambda a: a.title, items)
+    with codecs.open(output_file, 'w', 'utf-8') as f:
+            f.write(u"\n".join(items_title))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "sonos_ip_adress",
+        help="The local ip adress for one of your sonos speakers"
+    )
+    parser.add_argument(
+        "artist_file",
+        help="Name of file to dump artists (e.g. artists.txt)"
+    )
+    parser.add_argument(
+        "track_file",
+        help="Name of file to dump tracks (e.g. tracks.txt)"
+    )
+    parser.add_argument(
+        "playlist_file",
+        help="Name of file to dump playlists (e.g. playlists.txt)"
+    )
+        parser.add_argument(
+        "album_file",
+        help="Name of file to dump albums (e.g. albums.txt)"
+    )
+    args = parser.parse_args()    
+    
+    print "Dumping all artists to {}".format(args.artist_file)
+    dump_item_list(args.sonos_ip_adress, 'artists', args.artist_file)
+    
+    
+    print "Dumping all tracks to {}".format(args.track_file)
+    dump_item_list(args.sonos_ip_adress, 'tracks', args.track_file)
+    
+    print "Dumping all playlists to {}".format(args.playlist_file)
+    dump_item_list(args.sonos_ip_adress, 'playlists', args.playlist_file)
+    
+    print "Dumping all albums to {}".format(args.album_file)
+    dump_item_list(args.sonos_ip_adress, 'albums', args.album_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/get_local_library_data.py
+++ b/get_local_library_data.py
@@ -37,7 +37,7 @@ def main():
         "playlist_file",
         help="Name of file to dump playlists (e.g. playlists.txt)"
     )
-        parser.add_argument(
+    parser.add_argument(
         "album_file",
         help="Name of file to dump albums (e.g. albums.txt)"
     )

--- a/get_local_library_data.py
+++ b/get_local_library_data.py
@@ -8,7 +8,7 @@ import soco
 from soco.music_services import MusicService
 
 def dump_item_list(sonos_ip_adress, mode, output_file):
-    if mode not in ['artists', 'tracks', 'albums', 'playlists']:
+    if mode not in ['artists', 'tracks', 'albums', 'sonos_playlists']:
             raise ValueError("mode argument should be 'artists', 'tracks', 'albums' or 'playlists'")
     
     device = soco.core.SoCo(sonos_ip_adress)
@@ -16,6 +16,9 @@ def dump_item_list(sonos_ip_adress, mode, output_file):
     
     items = my_library.get_music_library_information(mode, complete_result=True)
     items_title = map(lambda a: a.title, items)
+    # only keep unique names
+    items_title = set(items_title)
+    items_title = list(items_title)
     with codecs.open(output_file, 'w', 'utf-8') as f:
             f.write(u"\n".join(items_title))
 
@@ -51,7 +54,7 @@ def main():
     dump_item_list(args.sonos_ip_adress, 'tracks', args.track_file)
     
     print "Dumping all playlists to {}".format(args.playlist_file)
-    dump_item_list(args.sonos_ip_adress, 'playlists', args.playlist_file)
+    dump_item_list(args.sonos_ip_adress, 'sonos_playlists', args.playlist_file)
     
     print "Dumping all albums to {}".format(args.album_file)
     dump_item_list(args.sonos_ip_adress, 'albums', args.album_file)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='1.0.0',
     description='Sonos skill for Snips',
     author='The Als',
-    url='https://github.com/snipsco/snips-skill-sonos',
+    url='https://github.com/darioce/snips-skill-sonos',
     download_url='',
     license='MIT',
     install_requires=['soco'],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='1.0.0',
     description='Sonos skill for Snips',
     author='The Als',
-    url='https://github.com/darioce/snips-skill-sonos',
+    url='https://github.com/snipsco/snips-skill-sonos',
     download_url='',
     license='MIT',
     install_requires=['soco'],

--- a/snipssonos/Snipsspec
+++ b/snipssonos/Snipsspec
@@ -18,7 +18,10 @@ intents:
       snips.skill.set_to_previous_volume()
       %}
   - intent: speakerInterrupt
-    action: "pause_sonos"
+    action: |
+      {%
+      snips.skill.stop_sonos()
+      %}
   - intent: volumeUp
     action: |
       {%

--- a/snipssonos/Snipsspec
+++ b/snipssonos/Snipsspec
@@ -20,7 +20,7 @@ intents:
   - intent: speakerInterrupt
     action: |
       {%
-      snips.skill.stop_sonos()
+      snips.skill.pause_sonos()
       %}
   - intent: volumeUp
     action: |

--- a/snipssonos/snipssonos.py
+++ b/snipssonos/snipssonos.py
@@ -22,6 +22,7 @@ class SnipsSonos:
     """ Sonos skill for Snips. """
 
     def __init__(self, spotify_refresh_token=None, speaker_index=None, locale=None, use_local_library=False, sonos_ip=None):
+        self.local_library = use_local_library
         # if ip is provided try to connect
         if sonos_ip is not None:
                 self.device = soco.core.SoCo(sonos_ip)
@@ -44,7 +45,7 @@ class SnipsSonos:
             self.tunein_service = MusicService('TuneIn')
         except Exception:
             self.tunein_service = None
-                self.max_volume = MAX_VOLUME
+        self.max_volume = MAX_VOLUME
         if spotify_refresh_token is not None:
             self.spotify = SpotifyClient(spotify_refresh_token)
         self.previous_volume = None
@@ -137,7 +138,7 @@ class SnipsSonos:
     def play_playlist(self, name, _shuffle=False):
         if self.device is None:
             return
-        if use_local_library is True:
+        if self.local_library is True:
             if self.my_library is None:
                 return
             playlist = self.my_library.get_playlists(search_term = name)[0]
@@ -166,7 +167,7 @@ class SnipsSonos:
     def play_artist(self, name):
         if self.device is None:
             return
-        if use_local_library is True:
+        if self.local_library is True:
             if self.my_library is None:
                 return
             artist = self.my_library.get_artists(search_term = name)[0]
@@ -191,7 +192,7 @@ class SnipsSonos:
     def play_album(self, name, _shuffle=False):
         if self.device is None:
             return
-        if use_local_library is True:
+        if self.local_library is True:
             if self.my_library is None:
                 return
             album = self.my_library.get_albums(search_term = name)[0]
@@ -220,7 +221,7 @@ class SnipsSonos:
     def play_song(self, name):
         if self.device is None:
             return
-        if use_local_library is True:
+        if self.local_library is True:
             if self.my_library is None:
                 return
             track = self.my_library.get_tracks(search_term = name)[0]


### PR DESCRIPTION
This change allows to pass the argument _use_local_library_ and _sonos_ip_ to the skill. It will search for artists, albums or tracks in the local sonos library instead of spotify.