### PR TITLE
Fix - Handle access token expiration

### DIFF
--- a/snipssonos/services/spotify/music_search_service.py
+++ b/snipssonos/services/spotify/music_search_service.py
@@ -15,8 +15,6 @@ class SpotifyMusicSearchService(MusicSearchService):
         self.client_id = client_id
         self.client_secret = client_secret
 
-        self.client = SpotifyClient(self.client_id, self.client_secret)
-
     def search_album(self, album_name):
         album_search_query = SpotifyAPISearchQueryBuilder() \
             .set_search_query() \


### PR DESCRIPTION
The access token was not renewed when it expired and a 401 was thrown causing the app to not respond to play commands. 